### PR TITLE
Add image tags for social media sharing

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,8 +20,10 @@
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ .Title }}" />
+<meta name="twitter:image" content="/img/revuo-monero.png">
 <meta property="og:site_name" content="{{ .Site.Title }}" />
 <meta property="og:title" content="{{ .Title }}" />
+<meta property="og:image" content="/img/revuo-monero.png">
 
 {{ with .OutputFormats.Get "rss" -}}
   {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,10 +20,10 @@
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="{{ .Title }}" />
-<meta name="twitter:image" content="/img/revuo-monero.png">
+<meta name="twitter:image" content="{{ if and (eq .Section "posts") (.Params.image) }}/{{ .Params.image }}{{ else }}/img/revuo-monero.png{{ end }}" />
 <meta property="og:site_name" content="{{ .Site.Title }}" />
 <meta property="og:title" content="{{ .Title }}" />
-<meta property="og:image" content="/img/revuo-monero.png">
+<meta property="og:image" content="{{ if and (eq .Section "posts") (.Params.image) }}/{{ .Params.image }}{{ else }}/img/revuo-monero.png{{ end }}" />
 
 {{ with .OutputFormats.Get "rss" -}}
   {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}


### PR DESCRIPTION
This pull request should fix the issue that preview images did not display in Telegram (and I added a tag for Twitter, too). However, I was unable to test it, because I don't have a Telegram client. :sweat_smile: 