### PR TITLE
fix: ccs percentage with integers

### DIFF
--- a/layouts/shortcodes/ccs_item.html
+++ b/layouts/shortcodes/ccs_item.html
@@ -8,6 +8,6 @@
 	{{ $goal := .Get "goal" }}
 	{{ $raised := .Get "raised" }}
 	{{ with $goal }}
-<p>Raised <b>{{ $raised }}</b> of <b>{{ $goal }}</b> XMR ({{ div ($raised) ($goal) | mul 100 | int }}%)</p>
+<p>Raised <b>{{ $raised }}</b> of <b>{{ $goal }}</b> XMR ({{ div (mul $raised 1.0) (mul $goal 1.0) | mul 100 | int }}%)</p>
 	{{ end }}
 </div>


### PR DESCRIPTION
When the `raised` or `goal` is an integer and the other is a float, the percentage becomes `0`. This commit fixes that by converting both to floats (by multiplying by `1.0`).